### PR TITLE
authlink added to Apollo Client in app.jsx to resolve authentication …

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -26,6 +26,7 @@ const authLink = setContext((_, { headers }) => {
 
 // The Apollo Client is initialized.
 const client = new ApolloClient({
+  link: authLink.concat(httpLink),
   uri: '/graphql',
   cache: new InMemoryCache(),
 });


### PR DESCRIPTION
The `authLink` was defined in App.jsx to include the token authorization in the headers, but it had not been added to the Apollo Client.  I corrected this by adding a link property to call the authLink function.  This has resolved issues where context was not being processed by the application to store books.